### PR TITLE
CLI: install res on basis of pipelines installed

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -24,6 +24,7 @@ require (
 	gorm.io/driver/postgres v1.0.2
 	gorm.io/gorm v1.20.7
 	gotest.tools/v3 v3.0.2
+	k8s.io/api v0.19.7
 	k8s.io/apimachinery v0.19.7
 	k8s.io/client-go v0.19.7
 	knative.dev/pkg v0.0.0-20210203171706-6045ed499615

--- a/api/pkg/cli/cmd/downgrade/downgrade_test.go
+++ b/api/pkg/cli/cmd/downgrade/downgrade_test.go
@@ -50,7 +50,7 @@ var resVersion = &res.ResourceVersionData{
 		},
 		Rating: 4.8,
 		Tags: []*res.Tag{
-			&res.Tag{
+			{
 				ID:   3,
 				Name: "cli",
 			},
@@ -81,7 +81,7 @@ func TestDowngrade_ResourceNotExist(t *testing.T) {
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
 
 	opts := &options{
-		cs:   test.FakeClientSet(cs.Pipeline, dynamic, "hub"),
+		cs:   test.FakeClientSet(cs.Pipeline, dynamic, "hub", cs.Kube),
 		cli:  cli,
 		kind: "task",
 		args: []string{"foo"},
@@ -109,7 +109,7 @@ func TestDowngrade_VersionCatalogMissing(t *testing.T) {
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
 
 	opts := &options{
-		cs:   test.FakeClientSet(cs.Pipeline, dynamic, "hub"),
+		cs:   test.FakeClientSet(cs.Pipeline, dynamic, "hub", cs.Kube),
 		cli:  cli,
 		kind: "task",
 		args: []string{"foo"},
@@ -138,7 +138,7 @@ func TestDowngrade_VersionMissing(t *testing.T) {
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
 
 	opts := &options{
-		cs:   test.FakeClientSet(cs.Pipeline, dynamic, "hub"),
+		cs:   test.FakeClientSet(cs.Pipeline, dynamic, "hub", cs.Kube),
 		cli:  cli,
 		kind: "task",
 		args: []string{"foo"},
@@ -194,7 +194,7 @@ func TestDowngrade(t *testing.T) {
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
 
 	opts := &options{
-		cs:   test.FakeClientSet(cs.Pipeline, dynamic, "hub"),
+		cs:   test.FakeClientSet(cs.Pipeline, dynamic, "hub", cs.Kube),
 		cli:  cli,
 		kind: "task",
 		args: []string{"foo"},
@@ -251,7 +251,7 @@ func TestDowngrade_ToSpecificVersion(t *testing.T) {
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
 
 	opts := &options{
-		cs:      test.FakeClientSet(cs.Pipeline, dynamic, "hub"),
+		cs:      test.FakeClientSet(cs.Pipeline, dynamic, "hub", cs.Kube),
 		cli:     cli,
 		kind:    "task",
 		args:    []string{"foo"},
@@ -306,7 +306,7 @@ func TestDowngrade_SameVersionError(t *testing.T) {
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
 
 	opts := &options{
-		cs:      test.FakeClientSet(cs.Pipeline, dynamic, "hub"),
+		cs:      test.FakeClientSet(cs.Pipeline, dynamic, "hub", cs.Kube),
 		cli:     cli,
 		kind:    "task",
 		args:    []string{"foo"},
@@ -356,7 +356,7 @@ func TestDowngrade_HigherVersionError(t *testing.T) {
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
 
 	opts := &options{
-		cs:      test.FakeClientSet(cs.Pipeline, dynamic, "hub"),
+		cs:      test.FakeClientSet(cs.Pipeline, dynamic, "hub", cs.Kube),
 		cli:     cli,
 		kind:    "task",
 		args:    []string{"foo"},

--- a/api/pkg/cli/cmd/reinstall/reinstall_test.go
+++ b/api/pkg/cli/cmd/reinstall/reinstall_test.go
@@ -50,7 +50,7 @@ var resVersion = &res.ResourceVersionData{
 		},
 		Rating: 4.8,
 		Tags: []*res.Tag{
-			&res.Tag{
+			{
 				ID:   3,
 				Name: "cli",
 			},
@@ -68,7 +68,7 @@ func TestReinstall_ResourceNotExist(t *testing.T) {
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
 
 	opts := &options{
-		cs:   test.FakeClientSet(cs.Pipeline, dynamic, "hub"),
+		cs:   test.FakeClientSet(cs.Pipeline, dynamic, "hub", cs.Kube),
 		cli:  cli,
 		kind: "task",
 		args: []string{"foo"},
@@ -96,7 +96,7 @@ func TestReinstall_VersionCatalogMissing(t *testing.T) {
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
 
 	opts := &options{
-		cs:   test.FakeClientSet(cs.Pipeline, dynamic, "hub"),
+		cs:   test.FakeClientSet(cs.Pipeline, dynamic, "hub", cs.Kube),
 		cli:  cli,
 		kind: "task",
 		args: []string{"foo"},
@@ -125,7 +125,7 @@ func TestReinstall_VersionMissing(t *testing.T) {
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
 
 	opts := &options{
-		cs:   test.FakeClientSet(cs.Pipeline, dynamic, "hub"),
+		cs:   test.FakeClientSet(cs.Pipeline, dynamic, "hub", cs.Kube),
 		cli:  cli,
 		kind: "task",
 		args: []string{"foo"},
@@ -171,7 +171,7 @@ func TestReinstall_DifferentVersionPassedByFlag(t *testing.T) {
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
 
 	opts := &options{
-		cs:      test.FakeClientSet(cs.Pipeline, dynamic, "hub"),
+		cs:      test.FakeClientSet(cs.Pipeline, dynamic, "hub", cs.Kube),
 		cli:     cli,
 		kind:    "task",
 		args:    []string{"foo"},
@@ -223,7 +223,7 @@ func TestReinstall_DifferentCatalogPassedByFlag(t *testing.T) {
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
 
 	opts := &options{
-		cs:      test.FakeClientSet(cs.Pipeline, dynamic, "hub"),
+		cs:      test.FakeClientSet(cs.Pipeline, dynamic, "hub", cs.Kube),
 		cli:     cli,
 		kind:    "task",
 		args:    []string{"foo"},
@@ -274,7 +274,7 @@ func TestReinstall(t *testing.T) {
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
 
 	opts := &options{
-		cs:   test.FakeClientSet(cs.Pipeline, dynamic, "hub"),
+		cs:   test.FakeClientSet(cs.Pipeline, dynamic, "hub", cs.Kube),
 		cli:  cli,
 		kind: "task",
 		args: []string{"foo"},

--- a/api/pkg/cli/cmd/upgrade/upgrade_test.go
+++ b/api/pkg/cli/cmd/upgrade/upgrade_test.go
@@ -50,7 +50,7 @@ var resVersion = &res.ResourceVersionData{
 		},
 		Rating: 4.8,
 		Tags: []*res.Tag{
-			&res.Tag{
+			{
 				ID:   3,
 				Name: "cli",
 			},
@@ -68,7 +68,7 @@ func TestUpgrade_ResourceNotExist(t *testing.T) {
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
 
 	opts := &options{
-		cs:   test.FakeClientSet(cs.Pipeline, dynamic, "hub"),
+		cs:   test.FakeClientSet(cs.Pipeline, dynamic, "hub", cs.Kube),
 		cli:  cli,
 		kind: "task",
 		args: []string{"foo"},
@@ -96,7 +96,7 @@ func TestUpgrade_VersionCatalogMissing(t *testing.T) {
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
 
 	opts := &options{
-		cs:   test.FakeClientSet(cs.Pipeline, dynamic, "hub"),
+		cs:   test.FakeClientSet(cs.Pipeline, dynamic, "hub", cs.Kube),
 		cli:  cli,
 		kind: "task",
 		args: []string{"foo"},
@@ -125,7 +125,7 @@ func TestUpgrade_VersionMissing(t *testing.T) {
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
 
 	opts := &options{
-		cs:   test.FakeClientSet(cs.Pipeline, dynamic, "hub"),
+		cs:   test.FakeClientSet(cs.Pipeline, dynamic, "hub", cs.Kube),
 		cli:  cli,
 		kind: "task",
 		args: []string{"foo"},
@@ -173,7 +173,7 @@ func TestUpgrade_ToSpecificVersion(t *testing.T) {
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
 
 	opts := &options{
-		cs:      test.FakeClientSet(cs.Pipeline, dynamic, "hub"),
+		cs:      test.FakeClientSet(cs.Pipeline, dynamic, "hub", cs.Kube),
 		cli:     cli,
 		kind:    "task",
 		args:    []string{"foo"},
@@ -220,7 +220,7 @@ func TestUpgrade_SameVersionError(t *testing.T) {
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
 
 	opts := &options{
-		cs:      test.FakeClientSet(cs.Pipeline, dynamic, "hub"),
+		cs:      test.FakeClientSet(cs.Pipeline, dynamic, "hub", cs.Kube),
 		cli:     cli,
 		kind:    "task",
 		args:    []string{"foo"},
@@ -267,7 +267,7 @@ func TestUpgrade_LowerVersionError(t *testing.T) {
 	cs.Pipeline.Resources = cb.APIResourceList(version, []string{"task"})
 
 	opts := &options{
-		cs:      test.FakeClientSet(cs.Pipeline, dynamic, "hub"),
+		cs:      test.FakeClientSet(cs.Pipeline, dynamic, "hub", cs.Kube),
 		cli:     cli,
 		kind:    "task",
 		args:    []string{"foo"},

--- a/api/pkg/cli/test/client.go
+++ b/api/pkg/cli/test/client.go
@@ -18,11 +18,13 @@ import (
 	"github.com/tektoncd/hub/api/pkg/cli/kube"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	"k8s.io/client-go/dynamic"
+	k8s "k8s.io/client-go/kubernetes"
 )
 
 type fakeClients struct {
 	tekton    versioned.Interface
 	dynamic   dynamic.Interface
+	kube      k8s.Interface
 	namespace string
 }
 
@@ -39,10 +41,16 @@ func (p *fakeClients) Namespace() string {
 	return p.namespace
 }
 
-func FakeClientSet(tekton versioned.Interface, dynamic dynamic.Interface, namespace string) *fakeClients {
+// Only returns kube client, not tekton client
+func (p *fakeClients) KubeClient() (k8s.Interface, error) {
+	return p.kube, nil
+}
+
+func FakeClientSet(tekton versioned.Interface, dynamic dynamic.Interface, namespace string, kube k8s.Interface) *fakeClients {
 	return &fakeClients{
 		tekton:    tekton,
 		dynamic:   dynamic,
 		namespace: namespace,
+		kube:      kube,
 	}
 }

--- a/api/pkg/cli/test/helpers.go
+++ b/api/pkg/cli/test/helpers.go
@@ -15,13 +15,57 @@
 package test
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
-	pipelinev1beta1test "github.com/tektoncd/pipeline/test"
 	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
+	pipelinev1beta1test "github.com/tektoncd/pipeline/test"
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8s "k8s.io/client-go/kubernetes"
 )
 
 func SeedV1beta1TestData(t *testing.T, d pipelinev1beta1test.Data) (pipelinev1beta1test.Clients, pipelinev1beta1test.Informers) {
-	ctx, _ :=ttesting.SetupFakeContext(t)
+	ctx, _ := ttesting.SetupFakeContext(t)
 	return pipelinev1beta1test.SeedTestData(t, ctx, d)
+}
+
+func GetDeploymentData(name, image string, deploymentLabels, podTemplateLabels, annotations map[string]string) *v1.Deployment {
+	return &v1.Deployment{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: deploymentLabels,
+		},
+		Spec: v1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      podTemplateLabels,
+					Annotations: annotations,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: image,
+					}},
+				},
+			},
+		},
+	}
+}
+
+func CreateTektonPipelineController(kube k8s.Interface, version string) error {
+	newDeploymentLabels := map[string]string{
+		"app.kubernetes.io/part-of":   "tekton-pipelines",
+		"app.kubernetes.io/component": "controller",
+		"app.kubernetes.io/name":      "controller",
+	}
+
+	deployment := GetDeploymentData("test", "", newDeploymentLabels, map[string]string{"app.kubernetes.io/version": version}, nil)
+
+	if _, err := kube.AppsV1().Deployments("tekton-pipelines").Create(context.Background(), deployment, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("failed to create deployment: %v", err)
+	}
+	return nil
 }

--- a/api/pkg/cli/version/version.go
+++ b/api/pkg/cli/version/version.go
@@ -1,0 +1,126 @@
+// Copyright © 2021 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	v1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8s "k8s.io/client-go/kubernetes"
+)
+
+const (
+	pipelinesControllerSelector    string = "app.kubernetes.io/part-of=tekton-pipelines,app.kubernetes.io/component=controller,app.kubernetes.io/name=controller"
+	oldPipelinesControllerSelector string = "app.kubernetes.io/component=controller,app.kubernetes.io/name=tekton-pipelines"
+	triggersControllerSelector     string = "app.kubernetes.io/part-of=tekton-triggers,app.kubernetes.io/component=controller,app.kubernetes.io/name=controller"
+	oldTriggersControllerSelector  string = "app.kubernetes.io/component=controller,app.kubernetes.io/name=tekton-triggers"
+	dashboardControllerSelector    string = "app.kubernetes.io/part-of=tekton-dashboard,app.kubernetes.io/component=dashboard,app.kubernetes.io/name=dashboard"
+	oldDashboardControllerSelector string = "app=tekton-dashboard"
+)
+
+// GetPipelineVersion Get pipeline version, functions imported from Dashboard
+func GetPipelineVersion(kube k8s.Interface) (string, error) {
+	deploymentsList, err := getDeployments(kube, pipelinesControllerSelector, oldPipelinesControllerSelector)
+
+	if err != nil {
+		return "", err
+	}
+
+	version := findPipelineVersion(deploymentsList.Items)
+
+	if version == "" {
+		return "", fmt.Errorf("error getting the tekton pipelines deployment version. Version is unknown")
+	}
+
+	return version, nil
+}
+
+// Get deployments for either Tekton Triggers, Tekton Dashboard or Tekton Pipelines
+func getDeployments(kube k8s.Interface, newLabel, oldLabel string) (*v1.DeploymentList, error) {
+	var (
+		err               error
+		deployments       *v1.DeploymentList
+		defaultNamespaces = []string{"tekton-pipelines", "openshift-pipelines"}
+	)
+
+	for _, n := range defaultNamespaces {
+		deployments, err = getDeploy(kube, newLabel, oldLabel, n)
+		if err != nil {
+			if strings.Contains(err.Error(), fmt.Sprintf(`cannot list resource "deployments" in API group "apps" in the namespace "%s"`, n)) {
+				continue
+			} else {
+				return nil, err
+			}
+		}
+		if len(deployments.Items) != 0 {
+			break
+		}
+	}
+	return deployments, err
+}
+
+func getDeploy(kube k8s.Interface, newLabel, oldLabel, ns string) (*v1.DeploymentList, error) {
+	deployments, err := kube.AppsV1().Deployments(ns).List(context.Background(), metav1.ListOptions{LabelSelector: newLabel})
+	if err != nil {
+		return nil, err
+	}
+
+	// NOTE: If the new labels selector returned nothing, try with old labels selector
+	// The old labels selectors are deprecated and should be removed at some point
+	if deployments == nil || len(deployments.Items) == 0 {
+		deployments, err = kube.AppsV1().Deployments(ns).List(context.Background(), metav1.ListOptions{LabelSelector: oldLabel})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return deployments, err
+}
+
+func findPipelineVersion(deployments []v1.Deployment) string {
+	version := ""
+	for _, deployment := range deployments {
+		deploymentLabels := deployment.Spec.Template.GetLabels()
+		deploymentAnnotations := deployment.Spec.Template.GetAnnotations()
+
+		// For master of Tekton Pipelines
+		version = deploymentLabels["app.kubernetes.io/version"]
+
+		// For Tekton Pipelines 0.11.*
+		if version == "" {
+			version = deploymentLabels["pipeline.tekton.dev/release"]
+		}
+
+		// For Tekton Pipelines 0.10.0 + 0.10.1 tekton.dev/release has been set as annotation
+		if version == "" {
+			version = deploymentAnnotations["tekton.dev/release"]
+		}
+
+		// For Tekton Pipelines 0.9.0 - 0.9.2
+		if version == "" {
+			deploymentImage := deployment.Spec.Template.Spec.Containers[0].Image
+			if strings.Contains(deploymentImage, "pipeline/cmd/controller") && strings.Contains(deploymentImage, ":") && strings.Contains(deploymentImage, "@") {
+				s := strings.SplitAfter(deploymentImage, ":")
+				if strings.Contains(s[1], "@") {
+					t := strings.Split(s[1], "@")
+					version = t[0]
+				}
+			}
+		}
+	}
+	return version
+}

--- a/api/pkg/cli/version/version_test.go
+++ b/api/pkg/cli/version/version_test.go
@@ -1,0 +1,88 @@
+// Copyright © 2021 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tektoncd/hub/api/pkg/cli/test"
+	pipelinev1beta1test "github.com/tektoncd/pipeline/test"
+	v1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetPipelineVersion(t *testing.T) {
+	oldDeploymentLabels := map[string]string{
+		"app.kubernetes.io/component": "controller",
+		"app.kubernetes.io/name":      "tekton-pipelines",
+	}
+
+	newDeploymentLabels := map[string]string{
+		"app.kubernetes.io/part-of":   "tekton-pipelines",
+		"app.kubernetes.io/component": "controller",
+		"app.kubernetes.io/name":      "controller",
+	}
+
+	testParams := []struct {
+		name                  string
+		namespace             string
+		userProvidedNamespace string
+		deployment            *v1.Deployment
+		want                  string
+	}{{
+		name:       "empty deployment items",
+		namespace:  "tekton-pipelines",
+		deployment: &v1.Deployment{},
+		want:       "",
+	}, {
+		name:       "deployment spec does not have labels and annotations specific to version (old labels)",
+		namespace:  "tekton-pipelines",
+		deployment: test.GetDeploymentData("dep1", "pipeline/cmd/controller:v0.9.0@sha256:5d23", oldDeploymentLabels, nil, nil),
+		want:       "v0.9.0",
+	}, {
+		name:       "deployment spec have annotation specific to version (old labels)",
+		namespace:  "openshift-pipelines",
+		deployment: test.GetDeploymentData("dep2", "", oldDeploymentLabels, nil, map[string]string{"tekton.dev/release": "v0.10.0"}),
+		want:       "v0.10.0",
+	}, {
+		name:       "deployment spec have labels specific to version (old labels)",
+		namespace:  "tekton-pipelines",
+		deployment: test.GetDeploymentData("dep3", "", oldDeploymentLabels, map[string]string{"pipeline.tekton.dev/release": "v0.11.0"}, nil),
+		want:       "v0.11.0",
+	}, {
+		name:       "deployment spec have labels specific to master version (new labels)",
+		namespace:  "tekton-pipelines",
+		deployment: test.GetDeploymentData("dep5", "", newDeploymentLabels, map[string]string{"app.kubernetes.io/version": "master-tekton-pipelines"}, nil),
+		want:       "master-tekton-pipelines",
+	}}
+	for _, tp := range testParams {
+		t.Run(tp.name, func(t *testing.T) {
+			cs, _ := test.SeedV1beta1TestData(t, pipelinev1beta1test.Data{})
+
+			p := test.FakeClientSet(cs.Pipeline, nil, "", cs.Kube)
+			kube, err := p.KubeClient()
+			if err != nil {
+				t.Errorf("failed to get client: %v", err)
+			}
+			if _, err := kube.AppsV1().Deployments(tp.namespace).Create(context.Background(), tp.deployment, metav1.CreateOptions{}); err != nil {
+				t.Errorf("failed to create deployment: %v", err)
+			}
+			version, _ := GetPipelineVersion(kube)
+			assert.Equal(t, tp.want, version)
+		})
+	}
+}


### PR DESCRIPTION
As of now when we do `tkn hub install task taskname` without taking care
of the version of Tekton Pipelines installed on the cluster and due to
this it might break the TaskRun or PipelineRun created by the user if
the required Pipelines version is greater than that installed on the
cluster. Eg buildah 0.2 requires pipelines minVersion to be 0.17.0 and
we have 0.16.3 installed on our cluster so when running this task it
will break.

With this patch we will respect the min version required to run the task
which we get from the annotation present in the task as
pipelines.minVersion and the installed pipelines version.
- If the installed pipelines version is greater than pipelines.minVersion value
then the task will be installed directly.
- If the installed pipelines version is lesser than pipelines.minVersion
value it will error out.
- If the pipelines controller is installed on another namespace other
than `tekton-pipelines` and `openshift-pipelines` then it will give the
warning and install the task.

Signed-off-by: vinamra28 <vinjain@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

